### PR TITLE
Fix: not working with queries

### DIFF
--- a/packages/esm-loader-svelte/src/index.ts
+++ b/packages/esm-loader-svelte/src/index.ts
@@ -31,6 +31,8 @@ try {
 const config = {
   resolve: (specifier: string, options: Options) => {
     const { debug, parentURL } = options
+    // remove query from specifier
+    specifier = specifier.split('?').shift()
     if (specifier.endsWith(EXT)) {
       if (debug) console.log(`[${NAME}] resolve: ${specifier}`)
       const url = new URL(specifier, parentURL).href


### PR DESCRIPTION
This should make it possible to import files with query strings.

Eg.

```javascript
import Component from './somefile.svelte?timestamp=12345678'
```